### PR TITLE
Update docs for GrovePi.Digital

### DIFF
--- a/lib/grovepi/digital.ex
+++ b/lib/grovepi/digital.ex
@@ -11,14 +11,14 @@ defmodule GrovePi.Digital do
 
   iex> GrovePi.Digital.set_pin_mode(pin, :input)
   :ok
+  iex> GrovePi.Digital.read(pin, 0)
+  1
+  iex> GrovePi.Digital.set_pin_mode(pin, :output)
+  :ok
   iex> GrovePi.Digital.write(pin, 1)
   :ok
   iex> GrovePi.Digital.write(pin, 0)
   :ok
-  iex> GrovePi.Digital.set_pin_mode(pin, :output)
-  :ok
-  iex> GrovePi.Digital.read(pin, 0)
-  1
   ```
   """
 


### PR DESCRIPTION
* Update example so `GrovePi.Digital.read` is after `:input`
* And so `GrovePi.Digital.write` is after `:output`

I noticed the examples in the `GrovePi.Digital` docs should be reversed when I was in the docs today.