### PR TITLE
Misc updates to PivotPi docs and fix to I2C.State

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ by adding `grovepi` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:grovepi, "~> 0.4.0"}]
+  [{:grovepi, "~> 0.5.1"}]
 end
 ```
 

--- a/lib/grovepi/i2c/state.ex
+++ b/lib/grovepi/i2c/state.ex
@@ -20,8 +20,7 @@ defmodule GrovePi.I2C.State do
   end
 
   def pop_all_writes(%State{} = state) do
-    {all_writes, new_state} = get_all_writes(state)
-    {all_writes, new_state}
+    Map.get_and_update(state, :writes, &(rev_and_update_writes(&1)))
   end
 
   def pop_last_write(%State{} = state) do
@@ -43,10 +42,6 @@ defmodule GrovePi.I2C.State do
   def pop_last_response(%State{responses: responses} = state) do
     [message | rest_responses] = responses
     {message, %{state | responses: rest_responses}}
-  end
-
-  defp get_all_writes(state) do
-    Map.get_and_update(state, :writes, &(rev_and_update_writes(&1)))
   end
 
   defp rev_and_update_writes(messages) do

--- a/lib/grovepi/pivotpi.ex
+++ b/lib/grovepi/pivotpi.ex
@@ -25,6 +25,10 @@ defmodule GrovePi.PivotPi do
   ```
   """
 
+  @type channel :: 1..8
+  @type angle :: 0..180
+  @type percent :: 0..100
+
   alias GrovePi.PivotPi.PCA9685
 
   @max_12_bit_value 4095
@@ -32,6 +36,7 @@ defmodule GrovePi.PivotPi do
   @doc """
   Move the Servo motor to a new position.  Accepts angle from 0-180.
   """
+  @spec angle(channel, angle) :: :ok | {:error, term}
   def angle(channel, angle) do
     pwm_to_send = @max_12_bit_value - translate_to_servo_range(angle)
     device_channel = channel - 1
@@ -46,6 +51,7 @@ defmodule GrovePi.PivotPi do
   @doc """
   Control the PivotPi LEDs.  Channel # should match Servo #.  Accepts % from 0-100.
   """
+  @spec led(channel, percent) :: :ok | {:error, term}
   def led(channel, percent) do
     pwm_to_send = translate_to_12_bit(percent)
     PCA9685.set_pwm(convert_to_led(channel), 0, pwm_to_send)
@@ -62,6 +68,7 @@ defmodule GrovePi.PivotPi do
   @doc """
   Initialize the PivotPi board.
   """
+  @spec start() :: :ok | {:error, term}
   def start() do
     PCA9685.start()
   end

--- a/lib/grovepi/pivotpi/PCA9685.ex
+++ b/lib/grovepi/pivotpi/PCA9685.ex
@@ -2,11 +2,18 @@ defmodule GrovePi.PivotPi.PCA9685 do
   alias GrovePi.Board
   use Bitwise
 
-  @moduledoc false
+  @moduledoc """
+  This module provides lower level functions to interact with the
+  [PivotPi](https://www.dexterindustries.com/pivotpi-tutorials-documentation/)
+  through the [GrovePi](https://www.dexterindustries.com/grovepi/).  Most users
+  should be able to obtain all needed functionality with `GrovePi.PivotPi`.
+  """
 
   # References
   # https://github.com/DexterInd/PivotPi/tree/master/Software/Python
   # https://www.nxp.com/docs/en/data-sheet/PCA9685.pdf
+
+  @type channel :: 0..15
 
   # registers/etc:
   @pca9685_address     0x40
@@ -40,6 +47,7 @@ defmodule GrovePi.PivotPi.PCA9685 do
 
   @default_freq        60
 
+  @doc false
   def start() do
     set_pwm_off(:all)
     initialize()
@@ -68,6 +76,7 @@ defmodule GrovePi.PivotPi.PCA9685 do
   Update the PWM on and off times on the specified channel
   or `:all` to write to update all channels.
   """
+  @spec set_pwm(channel | :all, integer, integer) :: :ok | {:error, term}
   def set_pwm(channel, on, off) do
     send_cmd(<<channel_to_register(channel),
                on::little-size(16),
@@ -77,6 +86,7 @@ defmodule GrovePi.PivotPi.PCA9685 do
   @doc """
   Turn the specified channel or `:all` ON.
   """
+  @spec set_pwm_on(channel | :all) :: :ok | {:error, term}
   def set_pwm_on(channel) do
     set_pwm(channel, 0x1000, 0)
   end
@@ -84,6 +94,7 @@ defmodule GrovePi.PivotPi.PCA9685 do
   @doc """
   Turn the specified channel or `:all` OFF.
   """
+  @spec set_pwm_off(channel | :all) :: :ok | {:error, term}
   def set_pwm_off(channel) do
     set_pwm(channel, 0, 0x1000)
   end
@@ -93,6 +104,7 @@ defmodule GrovePi.PivotPi.PCA9685 do
 
   defp frequency_to_prescale(hz), do: round(((25000000.0 / 4096.0) / hz) - 1.0)
 
+  @spec send_cmd(binary) :: :ok | {:error, term}
   def send_cmd(command) do
     Board.i2c_write_device(@pca9685_address, command)
   end

--- a/test/grovepi/pivotpi.exs
+++ b/test/grovepi/pivotpi.exs
@@ -8,21 +8,21 @@ defmodule GrovePi.PivotPiTest do
   end
 
   test "sets angle for a channel", %{board: board} do
-    channel = 10
+    channel_1 = 1
     angle = 90
 
-    GrovePi.PivotPi.angle(channel, angle)
+    GrovePi.PivotPi.angle(channel_1, angle)
 
-    assert <<42, 0, 0, 136, 14>> == GrovePi.I2C.get_last_write_data(board)
+    assert <<6, 0, 0, 136, 14>> == GrovePi.I2C.get_last_write_data(board)
   end
 
   test "sets led value for a channel", %{board: board} do
-    channel = 10
+    channel_1 = 1
     led_percent = 50
 
-    GrovePi.PivotPi.led(channel, led_percent)
+    GrovePi.PivotPi.led(channel_1, led_percent)
 
-    assert <<74, 0, 0, 0, 8>> == GrovePi.I2C.get_last_write_data(board)
+    assert <<38, 0, 0, 0, 8>> == GrovePi.I2C.get_last_write_data(board)
   end
 
   test "sends initialization commands", %{board: board} do


### PR DESCRIPTION
* Add Typespecs for `PivotPi` and `PCA9685` along with doc updates
* Fix `I2C.State` function...I considered typespecs, but I don't think the function should be a documented public function
* Update `README` for minor version update from 4 to 5
* Update channel in `PivotPi` test since channels on the board are only 1-8
* One thing to note about channels, when communicating with the device the channels are 0-7 (servos) and 8-15 (leds).  The `PivotPi` module makes adjustments for what is labeled on the PivotPi board: 1-8 for servos/leds.  The `PCA9686` module requires the channel used to communicate with the device, ie 0-15.

Let me know if you see any corrections you would like me to make.  I appreciate the feedback!

