### PR TITLE
Add Relay module & update PivotPi doc example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v0.6.0
+
+* Add PivotPi module to control servos
+* Add Relay module to control relay switch
+* Rename `start` functions to `initalize` in RGBLCD and PivotPi
+
 ## v0.5.1
 
 * Big changes in the RGBLCD module. Make sure to checkout the

--- a/examples/demo_pivotpi/lib/demo_pivotpi.ex
+++ b/examples/demo_pivotpi/lib/demo_pivotpi.ex
@@ -1,6 +1,6 @@
 defmodule DemoPivotPi do
   @moduledoc """
-  Sample functions to demonstrate and test GrovePi.RGBLCD module
+  Sample functions to demonstrate and test the GrovePi.PivotPi module
   """
 
   alias GrovePi.PivotPi
@@ -10,7 +10,7 @@ defmodule DemoPivotPi do
   channels 1-8.  Not required to have a servo in every channel.
   """
   def cycle_servos() do
-    PivotPi.start()
+    PivotPi.initialize()
     do_cycle_servos()
   end
 

--- a/examples/demo_rgblcd/lib/demo_rgblcd.ex
+++ b/examples/demo_rgblcd/lib/demo_rgblcd.ex
@@ -12,7 +12,7 @@ defmodule DemoRGBLCD do
   Shows autoscroll function
   """
   def autoscroll() do
-    {:ok, config} = RGBLCD.start()
+    {:ok, config} = RGBLCD.initialize()
     print_autoscroll(config)
   end
 
@@ -37,7 +37,7 @@ defmodule DemoRGBLCD do
   Toggles cursor blinking on and off every 3000ms
   """
   def blink() do
-    {:ok, config} = RGBLCD.start
+    {:ok, config} = RGBLCD.initialize()
     RGBLCD.set_text("hello world!")
     toggle_blink(config)
   end
@@ -54,7 +54,7 @@ defmodule DemoRGBLCD do
   Toggles the cursor on and off every 1500ms
   """
   def cursor() do
-    {:ok, config} = RGBLCD.start
+    {:ok, config} = RGBLCD.initialize()
     RGBLCD.set_text("hello world!")
     toggle_cursor(config)
   end
@@ -71,7 +71,7 @@ defmodule DemoRGBLCD do
   Demonstrates setting the RGB color
   """
   def colors() do
-    {:ok, _config} = RGBLCD.start()
+    {:ok, _config} = RGBLCD.initialize()
     toggle_colors()
   end
 
@@ -91,7 +91,7 @@ defmodule DemoRGBLCD do
   Toggles the display on and off every 1500ms
   """
   def display() do
-    {:ok, config} = RGBLCD.start
+    {:ok, config} = RGBLCD.initialize()
     RGBLCD.set_text("hello world!")
     toggle_display(config)
   end
@@ -123,7 +123,7 @@ defmodule DemoRGBLCD do
   Demonstrates text direction both ways
   """
   def text_direction() do
-    {:ok, config} = RGBLCD.start()
+    {:ok, config} = RGBLCD.initialize()
     do_text_direction(config)
   end
 
@@ -141,7 +141,7 @@ defmodule DemoRGBLCD do
   Demonstrates moving the cursor to the second line
   """
   def set_cursor() do
-    {:ok, config} = RGBLCD.start()
+    {:ok, config} = RGBLCD.initialize()
     {:ok, _new_config} = RGBLCD.cursor_on(config)
     do_set_cursor()
   end

--- a/examples/home_weather_display/lib/home_weather_display.ex
+++ b/examples/home_weather_display/lib/home_weather_display.ex
@@ -14,7 +14,7 @@ defmodule HomeWeatherDisplay do
   def init(dht_pin) do
     state = %HomeWeatherDisplay{dht: dht_pin}
 
-    RGBLCD.start()
+    RGBLCD.initialize()
     RGBLCD.set_text("Ready!")
 
     DHT.subscribe(dht_pin, :changed)

--- a/lib/grovepi/pivotpi.ex
+++ b/lib/grovepi/pivotpi.ex
@@ -69,8 +69,8 @@ defmodule GrovePi.PivotPi do
   @doc """
   Initialize the PivotPi board.
   """
-  @spec start() :: :ok | {:error, term}
-  def start() do
-    PCA9685.start()
+  @spec initialize() :: :ok | {:error, term}
+  def initialize() do
+    PCA9685.initialize()
   end
 end

--- a/lib/grovepi/pivotpi.ex
+++ b/lib/grovepi/pivotpi.ex
@@ -5,22 +5,23 @@ defmodule GrovePi.PivotPi do
   through the [GrovePi](https://www.dexterindustries.com/grovepi/).
 
   Plug your PivotPi into the GrovePi I2C-1 port.  Plug your servo motor into
-  channel 1. You must initialize the PivotPi board using `PivotPi.start()`.
+  channel 1. You must initialize the PivotPi board using
+  `GrovePi.PivotPi.initialize/0`.
 
   ```elixir
-  iex> PivotPi.start()
+  iex> GrovePi.PivotPi.start()
   :ok
-  iex> PivotPi.angle(1, 180)
+  iex> GrovePi.PivotPi.angle(1, 180)
   :ok
-  iex> PivotPi.angle(1, 90)
+  iex> GrovePi.PivotPi.angle(1, 90)
   :ok
-  iex> PivotPi.angle(1, 0)
+  iex> GrovePi.PivotPi.angle(1, 0)
   :ok
-  iex> PivotPi.led(1, 100)
+  iex> GrovePi.PivotPi.led(1, 100)
   :ok
-  iex> PivotPi.led(1, 50)
+  iex> GrovePi.PivotPi.led(1, 50)
   :ok
-  iex> PivotPi.led(1, 0)
+  iex> GrovePi.PivotPi.led(1, 0)
   :ok
   ```
   """

--- a/lib/grovepi/pivotpi/PCA9685.ex
+++ b/lib/grovepi/pivotpi/PCA9685.ex
@@ -48,13 +48,13 @@ defmodule GrovePi.PivotPi.PCA9685 do
   @default_freq        60
 
   @doc false
-  def start() do
+  def initialize() do
     set_pwm_off(:all)
-    initialize()
+    set_modes()
     set_pwm_freq(@default_freq)
   end
 
-  defp initialize() do
+  defp set_modes() do
     # Initialize the mode registers, but don't wake
     # the PCA9685 up yet.
     send_cmd(<<@mode1, @mode1_default ||| @mode1_sleep>>)

--- a/lib/grovepi/relay.ex
+++ b/lib/grovepi/relay.ex
@@ -1,0 +1,46 @@
+defmodule GrovePi.Relay do
+  @moduledoc """
+  Conveniences for controlling a [GrovePi Relay](http://wiki.seeed.cc/Grove-Relay/).
+  The relay should be connected to a Digital port (e.g. D3). The relay can
+  be connected to something with a larger load, i.e appliance or desk lamp,
+  which can then be controlled by the
+  [GrovePi](https://www.dexterindustries.com/grovepi/).
+
+  ```elixir
+  iex> pin = 3
+  3
+  iex> GrovePi.Relay.initialize(pin)
+  :ok
+  iex> GrovePi.Relay.on(pin)
+  :ok
+  iex> GrovePi.Relay.off(pin)
+  :ok
+  ```
+  """
+
+  alias GrovePi.Digital
+
+  @doc """
+  Turns off the appliance, lamp, etc. connected to the relay.
+  """
+  @spec off(GrovePi.pin) :: :ok | {:error, term}
+  def off(pin) do
+    Digital.write(pin, 0)
+  end
+
+  @doc """
+  Turns on the appliance, lamp, etc. connected to the relay.
+  """
+  @spec on(GrovePi.pin) :: :ok | {:error, term}
+  def on(pin) do
+    Digital.write(pin, 1)
+  end
+
+  @doc """
+  Sets the pin mode to output. Required prior to using `on/1` or `off/1`.
+  """
+  @spec initialize(GrovePi.pin) :: :ok | {:error, term}
+  def initialize(pin) do
+    Digital.set_pin_mode(pin, :output)
+  end
+end

--- a/lib/grovepi/rgblcd.ex
+++ b/lib/grovepi/rgblcd.ex
@@ -111,7 +111,7 @@ defmodule GrovePi.RGBLCD do
   Initializes the LCD Display.  Returns tuple with :ok, and
   %GrovePi.RGBLCD.Config{} with initial configuration.
   """
-  def start() do
+  def initialize() do
     clear_display()
 
     config = get_default_config()

--- a/test/grovepi/pivotpi.exs
+++ b/test/grovepi/pivotpi.exs
@@ -26,7 +26,7 @@ defmodule GrovePi.PivotPiTest do
   end
 
   test "sends initialization commands", %{board: board} do
-    GrovePi.PivotPi.start()
+    GrovePi.PivotPi.initialize()
 
     data =
       board

--- a/test/grovepi/pivotpi/PCA9685_test.exs
+++ b/test/grovepi/pivotpi/PCA9685_test.exs
@@ -8,7 +8,7 @@ defmodule GrovePi.PivotPi.PCA9685Test do
   end
 
   test "sends initialization commands", %{board: board} do
-    GrovePi.PivotPi.PCA9685.start()
+    GrovePi.PivotPi.PCA9685.initialize()
 
     messages = GrovePi.I2C.get_all_writes(board)
     %{address: address} = List.first(messages)

--- a/test/grovepi/relay_test.exs
+++ b/test/grovepi/relay_test.exs
@@ -1,0 +1,30 @@
+defmodule GrovePi.RelayTest do
+  use ExUnit.Case, async: true
+
+  alias GrovePi.Relay
+
+  setup do
+    board = GrovePi.Board.i2c_name(Default)
+    start_supervised({GrovePi.I2C, ["i2c-1", 0x04, name: board]})
+    relay_pin = 5
+    %{board: board, pin: relay_pin}
+  end
+
+  test "off/1 writes 0 to device to turn off", %{board: board, pin: pin} do
+    Relay.off(pin)
+
+    assert <<2, pin, 0, 0>> == GrovePi.I2C.get_last_write_data(board)
+  end
+
+  test "on/1 writes 1 to device to turn on", %{board: board, pin: pin} do
+    Relay.on(pin)
+
+    assert <<2, pin, 1, 0>> == GrovePi.I2C.get_last_write_data(board)
+  end
+
+  test "initialize/1 sets pin mode to output", %{board: board, pin: pin} do
+    Relay.initialize(pin)
+
+    assert <<5, pin, 1, 0>> == GrovePi.I2C.get_last_write_data(board)
+  end
+end


### PR DESCRIPTION
* Add module to make it easy to control a GrovePi Relay
* Added automated GrovePi.Relay tests (also tested on hardware)
* I didn't use `ComponentTestCase`.  I think the testing & module are simpler without handling `prefix`.  Also, to unit test the Relay module, I only need `GrovePi.I2C` and not the Registries started with `GrovePi.Supervisor` since I'm not using the Poller.  However let me know what you think, I may be missing something.
* Update PivotPi iex example to `alias GrovePi.PivotPi` 