### PR TITLE
Add tests for RGBLCD and I2C modules

### DIFF
--- a/lib/grovepi/i2c.ex
+++ b/lib/grovepi/i2c.ex
@@ -38,6 +38,10 @@ defmodule GrovePi.I2C do
     GenServer.call(pid, {:get_all_writes})
   end
 
+  def get_all_data(pid) do
+    GenServer.call(pid, {:get_all_data})
+  end
+
   @spec write(pid, binary) :: :ok
   def write(pid, message) do
     GenServer.call(pid, {:write, message})
@@ -72,6 +76,11 @@ defmodule GrovePi.I2C do
   def handle_call({:get_all_writes}, _from, state) do
     {writes, new_state} = State.pop_all_writes(state)
     {:reply, writes, new_state}
+  end
+
+  def handle_call({:get_all_data}, _from, state) do
+    {data, new_state} = State.pop_all_data(state)
+    {:reply, data, new_state}
   end
 
   def handle_call({:read,  _len}, _from, state) do

--- a/lib/grovepi/relay.ex
+++ b/lib/grovepi/relay.ex
@@ -1,6 +1,7 @@
 defmodule GrovePi.Relay do
   @moduledoc """
   Conveniences for controlling a [GrovePi Relay](http://wiki.seeed.cc/Grove-Relay/).
+
   The relay should be connected to a Digital port (e.g. D3). The relay can
   be connected to something with a larger load, i.e appliance or desk lamp,
   which can then be controlled by the

--- a/lib/grovepi/rgblcd.ex
+++ b/lib/grovepi/rgblcd.ex
@@ -2,6 +2,18 @@ defmodule GrovePi.RGBLCD do
   @moduledoc """
   Conveniences for controlling a RGB LCD Display.  The display should be connected
   to the I2C-1 port.
+
+  Example usage:
+  ```
+  iex> {:ok, config} = GrovePi.RGBLCD.initialize()
+  {:ok, %GrovePi.RGBLCD.Config{display_control: 12, entry_mode: 6, function: 56}}
+  iex> {:ok, new_config} = GrovePi.RGBLCD.cursor_on(config)
+  {:ok, %GrovePi.RGBLCD.Config{display_control: 14, entry_mode: 6, function: 56}}
+  iex> GrovePi.RGBLCD.set_rgb(0, 255, 0)
+  :ok
+  iex> GrovePi.RGBLCD.set_text("hello world!")
+  :ok
+  ```
   """
 
   # References
@@ -105,34 +117,6 @@ defmodule GrovePi.RGBLCD do
     send_lcd_cmd(new_entry_mode)
 
     {:ok, RGBLCD.Config.update_entry_mode(config, new_entry_mode)}
-  end
-
-  @doc """
-  Initializes the LCD Display.  Returns tuple with :ok, and
-  %GrovePi.RGBLCD.Config{} with initial configuration.
-  """
-  def initialize() do
-    clear_display()
-
-    config = get_default_config()
-
-    send_lcd_cmd(config.function)
-    send_lcd_cmd(config.display_control)
-    send_lcd_cmd(config.entry_mode)
-
-    #backlit init
-    send_rgb(@reg_mode1, 0)
-
-    # set LEDs controllable by both PWM and GRPPWM registers
-    send_rgb(@reg_output, 0xff)
-
-    # set reg_mode2 values
-    # 0010 0000 -> 0x20 (DMBLNK to 1, ie blinky mode)
-    send_rgb(@reg_mode2, 0x20)
-
-    set_color_white()
-
-    {:ok, config}
   end
 
   @doc """
@@ -307,6 +291,34 @@ defmodule GrovePi.RGBLCD do
   end
 
   @doc """
+  Initializes the LCD Display.  Returns tuple with :ok, and
+  %GrovePi.RGBLCD.Config{} with initial configuration.
+  """
+  def initialize() do
+    clear_display()
+
+    config = get_default_config()
+
+    send_lcd_cmd(config.function)
+    send_lcd_cmd(config.display_control)
+    send_lcd_cmd(config.entry_mode)
+
+    #backlit init
+    send_rgb(@reg_mode1, 0)
+
+    # set LEDs controllable by both PWM and GRPPWM registers
+    send_rgb(@reg_output, 0xff)
+
+    # set reg_mode2 values
+    # 0010 0000 -> 0x20 (DMBLNK to 1, ie blinky mode)
+    send_rgb(@reg_mode2, 0x20)
+
+    set_color_white()
+
+    {:ok, config}
+  end
+
+  @doc """
   Scroll display left. Accepts spaces (integer) as an argument, defaults to 1.
   """
   def scroll_left(spaces \\ 1) do
@@ -430,15 +442,18 @@ defmodule GrovePi.RGBLCD do
     send_chars(rest)
   end
 
-  defp send_lcd_cmd(cmd) do
+  @doc false
+  def send_lcd_cmd(cmd) do
     Board.i2c_write_device(@lcd_address, <<0x80, cmd>>)
   end
 
-  defp send_lcd_write(text) do
+  @doc false
+  def send_lcd_write(text) do
     Board.i2c_write_device(@lcd_address, <<0x40, text>>)
   end
 
-  defp send_rgb(address, value) do
+  @doc false
+  def send_rgb(address, value) do
     Board.i2c_write_device(@rgb_address, <<address, value>>)
   end
 

--- a/test/grovepi/i2c/state_test.exs
+++ b/test/grovepi/i2c/state_test.exs
@@ -1,0 +1,132 @@
+defmodule GrovePi.I2C.StateTest do
+  use ExUnit.Case, async: true
+
+  alias GrovePi.{I2C.State, I2C.Write}
+
+  @error {:error, :no_more_messages}
+
+  test "add_input adds a write" do
+    state = %State{responses: [], writes: []}
+    write = %Write{address: 0x01, data: 0x02}
+
+    new_state = State.add_input(state, write)
+
+    assert Enum.count(new_state.writes) == 1
+  end
+
+  test "add_responses adds a response" do
+    state = %State{responses: [], writes: []}
+    responses = [0x02, 0x03]
+
+    new_state = State.add_responses(state, responses)
+
+    assert Enum.count(new_state.responses) == 2
+  end
+
+  test "pop_all_writes return error if no writes" do
+    state = %State{responses: [], writes: []}
+
+    result = State.pop_all_writes(state)
+
+    assert  result == {@error, state}
+  end
+
+  test "pop_all_writes returns all writes" do
+    state =
+      %State{responses: [], writes: [
+        %Write{address: 0x01, data: 0x02},
+        %Write{address: 0x01, data: 0x01},
+      ]}
+
+    {writes, new_state} = State.pop_all_writes(state)
+
+    assert Enum.count(writes) == 2
+    assert new_state == %State{responses: [], writes: []}
+  end
+
+  test "pop_all_date return error if no writes" do
+    state = %State{responses: [], writes: []}
+
+    result = State.pop_all_data(state)
+
+    assert  result == {@error, state}
+  end
+
+  test "pop_all_data returns all writes" do
+    state =
+      %State{responses: [], writes: [
+        %Write{address: 0x01, data: 0x02},
+        %Write{address: 0x01, data: 0x01},
+      ]}
+
+    {data, new_state} = State.pop_all_data(state)
+
+    assert data == [0x01, 0x02]
+    assert new_state == %State{responses: [], writes: []}
+  end
+
+  test "pop_last_write return error if no writes" do
+    state = %State{responses: [], writes: []}
+
+    result = State.pop_last_write(state)
+
+    assert  result == {@error, state}
+  end
+
+  test "pop_last_write returns last write" do
+    state =
+      %State{responses: [], writes: [
+        %Write{address: 0x01, data: 0x02},
+        %Write{address: 0x01, data: 0x01},
+      ]}
+
+    {write, new_state} = State.pop_last_write(state)
+
+    assert write.data == 0x02
+    assert new_state ==
+      %State{responses: [], writes: [
+        %Write{address: 0x01, data: 0x01},
+      ]}
+  end
+
+  test "pop_last_write_data return error if no writes" do
+    state = %State{responses: [], writes: []}
+
+    result = State.pop_last_write_data(state)
+
+    assert  result == {@error, state}
+  end
+
+  test "pop_last_write_data returns last data" do
+    state =
+      %State{responses: [], writes: [
+        %Write{address: 0x01, data: 0x02},
+        %Write{address: 0x01, data: 0x01},
+      ]}
+
+    {data, new_state} = State.pop_last_write_data(state)
+
+    assert data == 0x02
+    assert new_state ==
+      %State{responses: [], writes: [
+        %Write{address: 0x01, data: 0x01},
+      ]}
+  end
+
+  test "pop_last_response returns error if no responses" do
+    state = %State{responses: [], writes: []}
+
+    result = State.pop_last_response(state)
+
+    assert result == {@error, state}
+  end
+
+  test "pop_last_response returns last response" do
+    state = %State{responses: [0x02, 0x03], writes: []}
+
+    {response, new_state} = State.pop_last_response(state)
+
+    assert response == 0x02
+    assert new_state == %State{responses: [0x03], writes: []}
+  end
+end

--- a/test/grovepi/rgblcd_test.exs
+++ b/test/grovepi/rgblcd_test.exs
@@ -1,0 +1,364 @@
+defmodule GrovePi.RGBLCDTest do
+  use ExUnit.Case, async: true
+
+  alias GrovePi.{Board, RGBLCD, I2C}
+
+  @lcd_cmd 0x80
+  @lcd_write 0x40
+
+  setup do
+    board = Board.i2c_name(Default)
+    start_supervised({I2C, ["i2c-1", "address", name: board]})
+    %{board: board, config: RGBLCD.get_default_config()}
+  end
+
+  test "returns default config" do
+    result = RGBLCD.get_default_config()
+
+    assert result ==
+      %RGBLCD.Config{
+        display_control: 12,
+        entry_mode: 6,
+        function: 56
+      }
+  end
+
+  test "autoscroll command", %{board: board, config: config} do
+    autoscroll = 0x07
+
+    {:ok, result} = RGBLCD.autoscroll(config)
+
+    assert result.entry_mode == autoscroll
+    assert <<@lcd_cmd, autoscroll>> == I2C.get_last_write_data(board)
+  end
+
+  test "autoscroll_off command", %{board: board, config: config} do
+    autoscroll_off = 0x06
+
+    {:ok, result} = RGBLCD.autoscroll_off(config)
+
+    assert result.entry_mode == autoscroll_off
+    assert <<@lcd_cmd, autoscroll_off>> == I2C.get_last_write_data(board)
+  end
+
+  test "clear_display command", %{board: board} do
+    clear_display = 0x01
+
+    RGBLCD.clear_display()
+
+    assert <<@lcd_cmd, clear_display>> == I2C.get_last_write_data(board)
+  end
+
+  test "cursor_blink_off command", %{board: board, config: config} do
+    cursor_blink_off = 12
+
+    {:ok, result} = RGBLCD.cursor_blink_off(config)
+
+    assert result.display_control == cursor_blink_off
+    assert <<@lcd_cmd, cursor_blink_off>> == I2C.get_last_write_data(board)
+  end
+
+  test "cursor_blink_on command", %{board: board, config: config} do
+    cursor_blink_on = 13
+
+    {:ok, result} = RGBLCD.cursor_blink_on(config)
+
+    assert result.display_control == cursor_blink_on
+    assert <<@lcd_cmd, cursor_blink_on>> == I2C.get_last_write_data(board)
+  end
+
+  test "cursor_left command", %{board: board} do
+    cursor_left = 20
+
+    :ok = RGBLCD.cursor_left()
+
+    assert <<@lcd_cmd, cursor_left>> == I2C.get_last_write_data(board)
+  end
+
+  test "cursor_left command with spaces", %{board: board} do
+    cursor_left = 20
+
+    :ok = RGBLCD.cursor_left(3)
+
+    assert I2C.get_all_data(board) ==
+      [
+        <<@lcd_cmd, cursor_left>>,
+        <<@lcd_cmd, cursor_left>>,
+        <<@lcd_cmd, cursor_left>>
+      ]
+  end
+
+  test "cursor_off", %{board: board, config: config} do
+    cursor_off = 12
+
+    {:ok, result} = RGBLCD.cursor_off(config)
+
+    assert result.display_control == cursor_off
+    assert <<@lcd_cmd, cursor_off>> == I2C.get_last_write_data(board)
+  end
+
+  test "cursor_on command", %{board: board, config: config} do
+    cursor_on = 14
+
+    {:ok, result} = RGBLCD.cursor_on(config)
+
+    assert result.display_control == cursor_on
+    assert <<@lcd_cmd, cursor_on>> == I2C.get_last_write_data(board)
+  end
+
+  test "cursor_right command", %{board: board} do
+    cursor_right = 16
+
+    :ok = RGBLCD.cursor_right()
+
+    assert <<@lcd_cmd, cursor_right>> == I2C.get_last_write_data(board)
+  end
+
+  test "cursor_right command with spaces", %{board: board} do
+    cursor_right = 16
+
+    :ok = RGBLCD.cursor_right(3)
+
+    assert I2C.get_all_data(board) ==
+      [
+        <<@lcd_cmd, cursor_right>>,
+        <<@lcd_cmd, cursor_right>>,
+        <<@lcd_cmd, cursor_right>>
+      ]
+  end
+
+  test "display_off command", %{board: board, config: config} do
+    display_off = 8
+
+    {:ok, result} = RGBLCD.display_off(config)
+
+    assert result.display_control == display_off
+    assert <<@lcd_cmd, display_off>> == I2C.get_last_write_data(board)
+  end
+
+  test "display_on command", %{board: board, config: config} do
+    display_on = 12
+
+    {:ok, result} = RGBLCD.display_on(config)
+
+    assert result.display_control == display_on
+    assert <<@lcd_cmd, display_on>> == I2C.get_last_write_data(board)
+  end
+
+  test "home command", %{board: board} do
+    home = 0x02
+
+    RGBLCD.home()
+
+    assert <<@lcd_cmd, home>> == I2C.get_last_write_data(board)
+  end
+
+  test "initialize command", %{board: board, config: config} do
+    lcd_address = 0x3e
+    rgb_address = 0x62
+
+    {:ok, result} = RGBLCD.initialize()
+
+    writes = I2C.get_all_writes(board)
+
+    assert config == result
+    assert Enum.map(writes, &({&1.address, &1.data})) ==
+      [
+        {lcd_address, <<@lcd_cmd, 1>>},
+        {lcd_address, <<@lcd_cmd, 56>>},
+        {lcd_address, <<@lcd_cmd, 12>>},
+        {lcd_address, <<@lcd_cmd, 6>>},
+        {rgb_address, <<0, 0>>},
+        {rgb_address, <<8, 255>>},
+        {rgb_address, <<1, 32>>},
+        {rgb_address, <<4, 255>>},
+        {rgb_address, <<3, 255>>},
+        {rgb_address, <<2, 255>>}
+      ]
+  end
+
+  test "scroll_left command", %{board: board} do
+    scroll_left = 28
+
+    :ok = RGBLCD.scroll_left()
+
+    assert <<@lcd_cmd, scroll_left>> == I2C.get_last_write_data(board)
+  end
+
+  test "scroll_left command with spaces", %{board: board} do
+    scroll_left = 28
+
+    :ok = RGBLCD.scroll_left(3)
+
+    assert I2C.get_all_data(board) ==
+      [
+        <<@lcd_cmd, scroll_left>>,
+        <<@lcd_cmd, scroll_left>>,
+        <<@lcd_cmd, scroll_left>>
+      ]
+  end
+
+  test "scroll_right command", %{board: board} do
+    scroll_right = 24
+
+    :ok = RGBLCD.scroll_right()
+
+    assert <<@lcd_cmd, scroll_right>> == I2C.get_last_write_data(board)
+  end
+
+  test "scroll_right command with spaces", %{board: board} do
+    scroll_right = 24
+
+    :ok = RGBLCD.scroll_right(3)
+
+    assert I2C.get_all_data(board) ==
+      [
+        <<@lcd_cmd, scroll_right>>,
+        <<@lcd_cmd, scroll_right>>,
+        <<@lcd_cmd, scroll_right>>
+      ]
+  end
+
+  test "set_color_white command", %{board: board} do
+    reg_red = 4
+    reg_green = 3
+    reg_blue = 2
+    max = 255
+
+    :ok = RGBLCD.set_color_white()
+
+    assert I2C.get_all_data(board) ==
+      [
+        <<reg_red, max>>,
+        <<reg_green, max>>,
+        <<reg_blue, max>>
+      ]
+  end
+
+  test "set_cursor first row", %{board: board} do
+    row = 0
+    column = 10
+    cursor_config = 138
+
+    RGBLCD.set_cursor(row, column)
+
+    assert <<@lcd_cmd, cursor_config>> == I2C.get_last_write_data(board)
+  end
+
+  test "set_cursor second row", %{board: board} do
+    row = 1
+    column = 10
+    cursor_config = 202
+
+    RGBLCD.set_cursor(row, column)
+
+    assert <<@lcd_cmd, cursor_config>> == I2C.get_last_write_data(board)
+  end
+
+  test "set_cursor second row if over 1", %{board: board} do
+    row = 4
+    column = 10
+    cursor_config = 202
+
+    RGBLCD.set_cursor(row, column)
+
+    assert <<@lcd_cmd, cursor_config>> == I2C.get_last_write_data(board)
+  end
+
+  test "set_rgb command", %{board: board} do
+    reg_red = 4
+    reg_green = 3
+    reg_blue = 2
+    red = 150
+    green = 100
+    blue = 50
+
+    :ok = RGBLCD.set_rgb(red, green, blue)
+
+    assert I2C.get_all_data(board) ==
+      [
+        <<reg_red, red>>,
+        <<reg_green, green>>,
+        <<reg_blue, blue>>
+      ]
+  end
+
+  test "set_text command", %{board: board} do
+    text = "Hello World"
+    clear_display = 0x01
+
+    :ok = RGBLCD.set_text(text)
+
+    assert I2C.get_all_data(board) ==
+      [
+        <<@lcd_cmd, clear_display>>,
+        "@H", "@e", "@l", "@l", "@o", "@ ", "@W", "@o", "@r", "@l", "@d"
+      ]
+  end
+
+  test "text_left_to_right command", %{board: board, config: config} do
+    left_to_right = 6
+
+    {:ok, result} = RGBLCD.text_left_to_right(config)
+
+    assert result.entry_mode == left_to_right
+    assert <<@lcd_cmd, left_to_right>> == I2C.get_last_write_data(board)
+  end
+
+  test "text_right_to_left command", %{board: board, config: config} do
+    right_to_left = 4
+
+    {:ok, result} = RGBLCD.text_right_to_left(config)
+
+    assert result.entry_mode == right_to_left
+    assert <<@lcd_cmd, right_to_left>> == I2C.get_last_write_data(board)
+  end
+
+  test "write_text command", %{board: board} do
+    text = "Hello World"
+
+    :ok = RGBLCD.write_text(text)
+
+    assert I2C.get_all_data(board) ==
+      [
+        "@H", "@e", "@l", "@l", "@o", "@ ", "@W", "@o", "@r", "@l", "@d"
+      ]
+  end
+
+  test "send_lcd_cmd command", %{board: board} do
+    lcd_address = 0x3e
+    cmd = 0x01
+
+    RGBLCD.send_lcd_cmd(cmd)
+
+    write = I2C.get_last_write(board)
+
+    assert lcd_address == write.address
+    assert <<@lcd_cmd, cmd>> == write.data
+  end
+
+  test "send_lcd_write command", %{board: board} do
+    lcd_address = 0x3e
+    letter_e = 101
+
+    RGBLCD.send_lcd_write(letter_e)
+
+    write = I2C.get_last_write(board)
+
+    assert lcd_address == write.address
+    assert <<@lcd_write, letter_e>> == write.data
+  end
+
+  test "send_rgb command", %{board: board} do
+    rgb_address = 0x62
+    red_reg = 4
+    red = 150
+
+    RGBLCD.send_rgb(red_reg, red)
+
+    write = I2C.get_last_write(board)
+
+    assert rgb_address == write.address
+    assert <<red_reg, red>> == write.data
+  end
+end


### PR DESCRIPTION
* Wrote tests for the `GrovePi.RGBLCD` and `GrovePi.I2C` modules.  
* Added `GrovePi.I2C.get_all_data` to assist with the `GrovePi.RGBLCD` tests.
* Put `GrovePi.RGBLCD.initialize/0` in alphabetical order.
* Made a couple of `GrovePi.RGBLCD` functions public to enable testing. I did not add them to docs since I don't expect them to be called directly by users of the library.
* Added example usage to `GrovePi.RGBLCD` docs.
* Added a line so the summary for `GrovePi.Relay` in the docs is only a sentence.

Let me know if you would like me to take a different approach with any of these.  I know you are working on a different approach for testing, but I thought it would be a good idea to have a baseline of tests for any future updates.